### PR TITLE
claude/session-011CUYg36ekPdSCNvDyQ7ezB

### DIFF
--- a/src/core/file_in_node.py
+++ b/src/core/file_in_node.py
@@ -51,6 +51,7 @@ class FileInNode(Node):
         - Reports detailed errors for file and parsing issues
     """
 
+    GLYPH = '⤵'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/file_out_node.py
+++ b/src/core/file_out_node.py
@@ -38,6 +38,7 @@ class FileOutNode(Node):
             Output file content: ["a", "b", "c"]
     """
 
+    GLYPH = '⤴'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/looper_node.py
+++ b/src/core/looper_node.py
@@ -92,6 +92,7 @@ class LooperNode(Node):
         use_test=True, test_number=5
         Result: Only processes iteration #5
     """
+    GLYPH = '⟲'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/make_list_node.py
+++ b/src/core/make_list_node.py
@@ -77,7 +77,7 @@ class MakeListNode(Node):
         - Non-string inputs return an empty string rather than raising an error
     """
 
-
+    GLYPH = '≣'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/merge_node.py
+++ b/src/core/merge_node.py
@@ -49,7 +49,7 @@ class MergeNode(Node):
     use_insert = boolian, inserts the insert_string at the head of each item in the list as they're merged together
     """
 
-
+    GLYPH = '⋈'
     SINGLE_INPUT = False
     SINGLE_OUTPUT = True
 

--- a/src/core/null_node.py
+++ b/src/core/null_node.py
@@ -9,6 +9,7 @@ class NullNode(Node):
     It has a single input and can connect its output to multiple other nodes.
     """
 
+    GLYPH = '∅'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/query_node.py
+++ b/src/core/query_node.py
@@ -92,6 +92,7 @@ class QueryNode(Node):
         - Consider using 'limit' for large prompt sets
     """
 
+    GLYPH = '⌘'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
     

--- a/src/core/section_node.py
+++ b/src/core/section_node.py
@@ -76,6 +76,7 @@ class SectionNode(Node):
         - Delimiter within prefix is treated as part of the prefix
     """
 
+    GLYPH = '§'
     SINGLE_OUTPUT = False
     SINGLE_INPUT = True
 

--- a/src/core/split_node.py
+++ b/src/core/split_node.py
@@ -54,6 +54,8 @@ class SplitNode(Node):
         - For random selection, count is capped at the input list length
     """
 
+    GLYPH = '⋔'
+
     def __init__(self, name: str, path: str, node_type: NodeType):
         super().__init__(name, path, [0.0, 0.0], node_type)
         self._is_time_dependent = True

--- a/src/core/text_node.py
+++ b/src/core/text_node.py
@@ -35,6 +35,7 @@ class TextNode(Node):
     Output: List[str]
     """
 
+    GLYPH = '¶'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 


### PR DESCRIPTION
Added GLYPH class variable to each node type containing the corresponding character from src/TUI/node_type_emojis.py. This provides a visual representation of each node type that can be used in the TUI.

Node glyphs added:
- LooperNode: ⟲
- QueryNode: ⌘
- TextNode: ¶
- FileInNode: ⤵
- FileOutNode: ⤴
- SplitNode: ⋔
- SectionNode: §
- MakeListNode: ≣
- MergeNode: ⋈
- NullNode: ∅

🤖 Generated with [Claude Code](https://claude.com/claude-code)