### PR TITLE
claude/session-011CUaFFC8LAy5JZBHNjDzMK

### DIFF
--- a/src/api/routers/nodes.py
+++ b/src/api/routers/nodes.py
@@ -195,6 +195,8 @@ def get_node(
             }
         )
 
+    return node_to_response(target_node)
+
 
 @router.post(
     "/nodes",


### PR DESCRIPTION
The get_node() function was missing a return statement after successfully finding a node, causing it to return None instead of the node data. This resulted in 404 errors when the GUI tried to interact with nodes (e.g., selecting nodes, changing positions).

Added the missing return statement at src/api/routers/nodes.py:198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)