### PR TITLE
Debug session_id attribute being rewritten

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -68,7 +68,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
   // Handle node selection
   const onNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
-      selectNode(Number(node.id));
+      selectNode(node.id);
     },
     [selectNode]
   );
@@ -81,7 +81,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
   // Handle selection changes
   const onSelectionChange = useCallback(
     ({ nodes: selectedNodes }: { nodes: Node[] }) => {
-      const selectedIds = selectedNodes.map(n => Number(n.id));
+      const selectedIds = selectedNodes.map(n => n.id);
       selectNodes(selectedIds);
     },
     [selectNodes]
@@ -90,7 +90,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
   // Handle node drag end - save position to backend
   const onNodeDragStop = useCallback(
     async (_event: unknown, node: Node) => {
-      const sessionId = Number(node.id);
+      const sessionId = node.id;
       const newPosition: [number, number] = [node.position.x, node.position.y];
 
       console.log('[GraphCanvas] onNodeDragStop triggered:', {
@@ -119,7 +119,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
       try {
         await Promise.all(
           selectedNodes.map(node => {
-            const sessionId = Number(node.id);
+            const sessionId = node.id;
             const newPosition: [number, number] = [node.position.x, node.position.y];
 
             console.log('[GraphCanvas] onSelectionDragStop: updating node:', {

--- a/src/GUI/src/WorkspaceContext.tsx
+++ b/src/GUI/src/WorkspaceContext.tsx
@@ -9,19 +9,19 @@ interface WorkspaceContextType {
   nodes: NodeResponse[];
   connections: ConnectionResponse[];
   globals: Record<string, string | number | boolean>;
-  selectedNodeId: number | null;
-  selectedNodeIds: number[];
+  selectedNodeId: string | null;
+  selectedNodeIds: string[];
   loading: boolean;
   error: string | null;
   loadWorkspace: () => Promise<void>;
-  selectNode: (sessionId: number | null) => void;
-  selectNodes: (sessionIds: number[]) => void;
+  selectNode: (sessionId: string | null) => void;
+  selectNodes: (sessionIds: string[]) => void;
   getSelectedNode: () => NodeResponse | null;
   getSelectedNodes: () => NodeResponse[];
   createNode: (request: NodeCreateRequest) => Promise<NodeResponse>;
-  updateNode: (sessionId: number, request: NodeUpdateRequest) => Promise<NodeResponse>;
-  deleteNode: (sessionId: number) => Promise<void>;
-  deleteNodes: (sessionIds: number[]) => Promise<void>;
+  updateNode: (sessionId: string, request: NodeUpdateRequest) => Promise<NodeResponse>;
+  deleteNode: (sessionId: string) => Promise<void>;
+  deleteNodes: (sessionIds: string[]) => Promise<void>;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
@@ -30,8 +30,8 @@ export const WorkspaceProvider: React.FC<{ children: ReactNode }> = ({ children 
   const [nodes, setNodes] = useState<NodeResponse[]>([]);
   const [connections, setConnections] = useState<ConnectionResponse[]>([]);
   const [globals, setGlobals] = useState<Record<string, string | number | boolean>>({});
-  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
-  const [selectedNodeIds, setSelectedNodeIds] = useState<number[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,12 +53,12 @@ export const WorkspaceProvider: React.FC<{ children: ReactNode }> = ({ children 
     }
   }, []);
 
-  const selectNode = useCallback((sessionId: number | null) => {
+  const selectNode = useCallback((sessionId: string | null) => {
     setSelectedNodeId(sessionId);
     setSelectedNodeIds(sessionId !== null ? [sessionId] : []);
   }, []);
 
-  const selectNodes = useCallback((sessionIds: number[]) => {
+  const selectNodes = useCallback((sessionIds: string[]) => {
     setSelectedNodeIds(sessionIds);
     setSelectedNodeId(sessionIds.length === 1 ? sessionIds[0] : null);
   }, []);
@@ -90,7 +90,7 @@ export const WorkspaceProvider: React.FC<{ children: ReactNode }> = ({ children 
     }
   }, []);
 
-  const updateNode = useCallback(async (sessionId: number, request: NodeUpdateRequest): Promise<NodeResponse> => {
+  const updateNode = useCallback(async (sessionId: string, request: NodeUpdateRequest): Promise<NodeResponse> => {
     console.log('[WorkspaceContext] updateNode called:', {
       sessionId,
       sessionIdType: typeof sessionId,
@@ -131,7 +131,7 @@ export const WorkspaceProvider: React.FC<{ children: ReactNode }> = ({ children 
     }
   }, [nodes]);
 
-  const deleteNode = useCallback(async (sessionId: number): Promise<void> => {
+  const deleteNode = useCallback(async (sessionId: string): Promise<void> => {
     setLoading(true);
     setError(null);
 
@@ -157,7 +157,7 @@ export const WorkspaceProvider: React.FC<{ children: ReactNode }> = ({ children 
     }
   }, [selectedNodeId]);
 
-  const deleteNodes = useCallback(async (sessionIds: number[]): Promise<void> => {
+  const deleteNodes = useCallback(async (sessionIds: string[]): Promise<void> => {
     if (sessionIds.length === 0) return;
 
     setLoading(true);

--- a/src/GUI/src/apiClient.ts
+++ b/src/GUI/src/apiClient.ts
@@ -53,7 +53,7 @@ class ApiClient {
     });
   }
 
-  async updateNode(sessionId: number, request: NodeUpdateRequest): Promise<NodeResponse> {
+  async updateNode(sessionId: string, request: NodeUpdateRequest): Promise<NodeResponse> {
     console.log('[ApiClient] updateNode called:', {
       sessionId,
       sessionIdType: typeof sessionId,
@@ -76,13 +76,13 @@ class ApiClient {
     return response;
   }
 
-  async deleteNode(sessionId: number): Promise<void> {
+  async deleteNode(sessionId: string): Promise<void> {
     await this.fetchJson<void>(`/nodes/${sessionId}`, {
       method: 'DELETE',
     });
   }
 
-  async getNode(sessionId: number): Promise<NodeResponse> {
+  async getNode(sessionId: string): Promise<NodeResponse> {
     return this.fetchJson<NodeResponse>(`/nodes/${sessionId}`);
   }
 

--- a/src/GUI/src/types.ts
+++ b/src/GUI/src/types.ts
@@ -22,7 +22,7 @@ export interface OutputInfo {
 }
 
 export interface NodeResponse {
-  session_id: number;
+  session_id: string;
   name: string;
   path: string;
   type: string;
@@ -41,11 +41,11 @@ export interface NodeResponse {
 }
 
 export interface ConnectionResponse {
-  source_node_session_id: number;
+  source_node_session_id: string;
   source_node_path: string;
   source_output_index: number;
   source_output_name: string;
-  target_node_session_id: number;
+  target_node_session_id: string;
   target_node_path: string;
   target_input_index: number;
   target_input_name: string;

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -152,7 +152,7 @@ class NodeResponse(BaseModel):
         }
     """
     # Core identification
-    session_id: int = Field(..., description="Unique session identifier")
+    session_id: str = Field(..., description="Unique session identifier")
     name: str = Field(..., description="Node name (may not be unique)")
     path: str = Field(..., description="Full path (unique identifier)")
     type: str = Field(..., description="Node type (e.g., 'text', 'fileout', 'query')")
@@ -237,13 +237,13 @@ class ConnectionResponse(BaseModel):
         }
     """
     # Source (output) side
-    source_node_session_id: int = Field(..., description="Source node's session ID")
+    source_node_session_id: str = Field(..., description="Source node's session ID")
     source_node_path: str = Field(..., description="Source node's path")
     source_output_index: int = Field(..., description="Output socket index")
     source_output_name: str = Field(..., description="Output socket name")
     
     # Target (input) side
-    target_node_session_id: int = Field(..., description="Target node's session ID")
+    target_node_session_id: str = Field(..., description="Target node's session ID")
     target_node_path: str = Field(..., description="Target node's path")
     target_input_index: int = Field(..., description="Input socket index")
     target_input_name: str = Field(..., description="Input socket name")

--- a/src/api/routers/nodes.py
+++ b/src/api/routers/nodes.py
@@ -159,7 +159,7 @@ def list_nodes() -> List[NodeResponse]:
     }
 )
 def get_node(
-    session_id: int = Path(..., description="Unique session ID of the node")
+    session_id: str = Path(..., description="Unique session ID of the node")
 ) -> NodeResponse:
     """
     Get detailed information about a specific node.
@@ -340,7 +340,7 @@ def create_node(request: 'NodeCreateRequest') -> 'NodeResponse':
     }
 )
 def update_node(
-    session_id: int,
+    session_id: str,
     request: NodeUpdateRequest = Body(...)
 ) -> NodeResponse:
     """
@@ -487,7 +487,7 @@ def update_node(
     }
 )
 def delete_node(
-    session_id: int = Path(..., description="Node session ID")
+    session_id: str = Path(..., description="Node session ID")
 ) -> SuccessResponse:
     """
     Delete a node.
@@ -554,7 +554,7 @@ def delete_node(
     }
 )
 def execute_node(
-    session_id: int = Path(..., description="Node session ID")
+    session_id: str = Path(..., description="Node session ID")
 ) -> ExecutionResponse:
     """
     Execute a node (cook it).

--- a/src/core/mobile_item.py
+++ b/src/core/mobile_item.py
@@ -25,11 +25,11 @@ class MobileItem(NetworkEntity):
         _position (Tuple[float, float]): The x, y position of the item.
         _session_id (str): A unique identifier for the session.
 
-    Class Attributes:session 
-        _existing_session_ids (Set[int]): A set of all existing session IDs.
+    Class Attributes:session
+        _existing_session_ids (Set[str]): A set of all existing session IDs.
         all_MobileItems : A global list of nodes for UndoManager
     """
-    _existing_session_ids: Set[int] = set()
+    _existing_session_ids: Set[str] = set()
     all_MobileItems = []
 
     def __init__(self, name: str, path: str, position=[0.0, 0.0]) ->None:
@@ -57,7 +57,7 @@ class MobileItem(NetworkEntity):
         self._position: Tuple[float, float] = position
 
         logger.info(f"[MOBILE_ITEM_INIT] About to generate session_id...")
-        self._session_id: int = self._generate_unique_session_id()
+        self._session_id: str = self._generate_unique_session_id()
         logger.info(f"[MOBILE_ITEM_INIT] Generated session_id: {self._session_id} (type: {type(self._session_id)})")
         logger.info(f"[MOBILE_ITEM_INIT] === END MobileItem.__init__ for path={path} ===")
 
@@ -172,12 +172,12 @@ class MobileItem(NetworkEntity):
         return new_items
 
     @classmethod
-    def _generate_unique_session_id(cls) ->int:
+    def _generate_unique_session_id(cls) ->str:
         """
-        Generate a unique integer session ID.
+        Generate a unique string session ID.
 
         Returns:
-            int: A unique session ID.
+            str: A unique session ID (UUID as string).
 
         Raises:
             RuntimeError: If unable to generate a unique ID after 100 attempts.
@@ -203,9 +203,9 @@ class MobileItem(NetworkEntity):
         raise RuntimeError('Unable to generate a unique session ID')
 
     @staticmethod
-    def _generate_session_id() ->int:
-        """Generate an integer session ID using UUID."""
-        return uuid.uuid4().int & (1 << 63) - 1
+    def _generate_session_id() ->str:
+        """Generate a string session ID using UUID."""
+        return str(uuid.uuid4())
 
     def __repr__(self) ->str:
         """Return a string representation of the MobileItem."""


### PR DESCRIPTION
… type

This commit addresses the mysterious session_id rewriting issue with two fixes:

1. **Remove session_id restoration from undo/redo** (undo_manager.py)
   - Session IDs are now permanent and NEVER change once assigned
   - Undo/redo will restore position, parameters, etc., but keep session_id stable
   - This fixes the issue where undo/redo was actively rewriting session_ids

2. **Change session_id from int to string** (all files)
   - Backend: Changed from `int` to `str` in models, routers, and core classes
   - Frontend: Changed from `number` to `string` in TypeScript types
   - Uses UUID strings instead of large integers to avoid JavaScript precision loss
   - This fixes the precision issue where large integers were losing precision during JSON serialization (e.g., 1176526878150903684 → 1176526878150903800)

Philosophy: Session IDs are stable, permanent identifiers that should NEVER change after creation. They are used by the frontend to track nodes across operations and should remain constant for the lifetime of the node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)