### PR TITLE
Fix node selection click handling

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -46,9 +46,10 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
       type: 'custom',
       position: { x: node.position[0], y: node.position[1] },
       data: { node },
+      selected: selectedNodeIds.includes(String(node.session_id)),
     }));
     setNodes(flowNodes);
-  }, [workspaceNodes, setNodes]);
+  }, [workspaceNodes, selectedNodeIds, setNodes]);
 
   // Convert connections to React Flow edges
   useEffect(() => {


### PR DESCRIPTION
…ates

The issue was that when nodes were recreated in the React Flow canvas (which happens after node updates like position changes), the 'selected' property was not being set. This caused nodes to appear deselected immediately after being clicked and moved.

Changes:
- Add 'selected' property to React Flow nodes based on selectedNodeIds state
- Include selectedNodeIds in the useEffect dependency array to sync selection state

This ensures that when the nodes array is recreated, the selection state is preserved from the WorkspaceContext, fixing the automatic deselection bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)