### PR TITLE
Fix node selection not persisting after click

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -29,7 +29,6 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
     nodes: workspaceNodes,
     connections,
     selectNode,
-    selectNodes,
     selectedNodeIds,
     updateNode,
     deleteNodes,
@@ -77,15 +76,6 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
   const onPaneClick = useCallback(() => {
     selectNode(null);
   }, [selectNode]);
-
-  // Handle selection changes
-  const onSelectionChange = useCallback(
-    ({ nodes: selectedNodes }: { nodes: Node[] }) => {
-      const selectedIds = selectedNodes.map(n => n.id);
-      selectNodes(selectedIds);
-    },
-    [selectNodes]
-  );
 
   // Handle node drag end - save position to backend
   const onNodeDragStop = useCallback(
@@ -208,7 +198,6 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onRenameRequested }) =
         onEdgesChange={onEdgesChange}
         onNodeClick={onNodeClick}
         onPaneClick={onPaneClick}
-        onSelectionChange={onSelectionChange}
         onNodeDragStop={onNodeDragStop}
         onSelectionDragStop={onSelectionDragStop}
         nodeTypes={nodeTypes}


### PR DESCRIPTION
The node selection was being cleared when the user released the mouse button after clicking or dragging a node. This was caused by React Flow's onSelectionChange event being triggered with an empty selection array when drag operations ended, which sent selected=false to the backend.

Fixed by removing the redundant onSelectionChange handler. Selection is now properly managed through onNodeClick (for selecting nodes) and onPaneClick (for deselecting). This ensures nodes stay selected after drag operations, providing the expected "sticky" selection behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)