### PR TITLE
Fix node selection and drag behavior in GraphCanvas

### DIFF
--- a/src/GUI/src/CustomNode.tsx
+++ b/src/GUI/src/CustomNode.tsx
@@ -1,6 +1,6 @@
 // Custom Node Component - Displays node in React Flow graph
 
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { Handle, Position } from '@xyflow/react';
 import type { NodeResponse } from './types';
 
@@ -10,21 +10,7 @@ interface CustomNodeData {
 
 export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> = ({ data, selected }) => {
   const { node } = data;
-  const prevSelectedRef = useRef(selected);
 
-  // Log selection changes
-  useEffect(() => {
-    if (prevSelectedRef.current !== selected) {
-      console.log('[SELECTION] CustomNode selection changed:', {
-        nodeId: node.session_id,
-        nodeName: node.name,
-        wasSelected: prevSelectedRef.current,
-        nowSelected: selected
-      });
-      prevSelectedRef.current = selected;
-    }
-  }, [selected, node.session_id, node.name]);
-  
   // State color mapping
   const getStateColor = (state: string): string => {
     switch (state) {


### PR DESCRIPTION
**Critical Fix:**
- Line 239: Changed `onNodesChange={onNodesChange}` to `onNodesChange={handleNodesChange}` This was preventing the selection filter from working, causing React Flow to override manual selection changes

**Improvements:**
- Removed excessive console.log statements cluttering the code
- Added focused debugging with clear tags: [CLICK], [SELECT], [MULTI-SELECT], [MOVEMENT], [DRAG-END]
- Fixed `handleNodesChange` to properly log blocked selection changes and movements
- Cleaned up CustomNode component by removing selection change logging

This should fix the issue where clicking an already-selected node would deselect it instead of keeping it selected for drag-to-move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)