### PR TITLE
Keep node selected after moving

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -38,18 +38,20 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onSelectionChange }) =
 
   // Convert workspace nodes to React Flow nodes
   useEffect(() => {
-    const flowNodes: Node[] = workspaceNodes.map((node: NodeResponse) => {
-      const nodeId = String(node.session_id);
+    setNodes(prevNodes =>
+      workspaceNodes.map((node: NodeResponse) => {
+        const nodeId = String(node.session_id);
+        const existingNode = prevNodes.find(n => n.id === nodeId);
 
-      return {
-        id: nodeId,
-        type: 'custom',
-        position: { x: node.position[0], y: node.position[1] },
-        data: { node },
-      };
-    });
-
-    setNodes(flowNodes);
+        return {
+          id: nodeId,
+          type: 'custom',
+          position: { x: node.position[0], y: node.position[1] },
+          data: { node },
+          selected: existingNode?.selected ?? false,
+        };
+      })
+    );
   }, [workspaceNodes, setNodes]);
 
   // Convert connections to React Flow edges


### PR DESCRIPTION
Previously, when a node was moved, its position update triggered a workspace state change which recreated all React Flow nodes without preserving their selection state, causing nodes to become deselected.

Now we use the functional form of setNodes to preserve the selected property from existing nodes when syncing workspace changes.

Fixes issue where nodes would lose selection after being moved.