### PR TITLE
Add glyph attributes to all node types

### DIFF
--- a/src/core/folder_node.py
+++ b/src/core/folder_node.py
@@ -48,6 +48,7 @@ class FolderNode(Node):
             Output[2]: ["", "Permission denied: /path/file2.txt"]
     """
 
+    GLYPH = '📁'
     SINGLE_INPUT = False
     SINGLE_OUTPUT = False
 

--- a/src/core/input_null_node.py
+++ b/src/core/input_null_node.py
@@ -21,6 +21,8 @@ class InputNullNode(Node):
         in_data (STRINGLIST) : data from that node
     """
 
+    GLYPH = '▷'
+
     def __init__(self, name: str, path: str, node_type: NodeType):
         super().__init__(name, path, [0.0, 0.0], node_type)
         self._is_time_dependent = False

--- a/src/core/json_node.py
+++ b/src/core/json_node.py
@@ -49,6 +49,7 @@ class JsonNode(Node):
     Output: List[str] (extracted values as strings)
     """
 
+    GLYPH = '{'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 

--- a/src/core/output_null_node.py
+++ b/src/core/output_null_node.py
@@ -15,10 +15,11 @@ class OutputNullNode(Node):
         _input_hash (str): Hash of the last processed input.
         _last_input_size (int): Size of the last processed input.
 
-    Parameter: 
+    Parameter:
         out_date (STRINGLIST) : duplication of this node's input
     """
 
+    GLYPH = '◁'
     SINGLE_INPUT = True
     SINGLE_OUTPUT = True
 


### PR DESCRIPTION
Added GLYPH class attributes to nodes that were missing them:
- FolderNode: 📁 (folder emoji)
- JsonNode: { (left curly brace)
- InputNullNode: ▷ (white right triangle)
- OutputNullNode: ◁ (white left triangle)

All node types now have their visual glyph identifiers properly defined.