### PR TITLE
Simplify React node display layout

### DIFF
--- a/src/GUI/src/CustomNode.tsx
+++ b/src/GUI/src/CustomNode.tsx
@@ -51,48 +51,63 @@ export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> 
       ))}
 
       {/* Node content */}
-      <div style={{ marginBottom: '4px' }}>
-        <div style={{ 
-          fontWeight: 'bold', 
-          fontSize: '14px',
-          marginBottom: '2px',
-        }}>
-          {node.name}
-        </div>
-        <div style={{ 
-          fontSize: '11px', 
-          color: '#666',
-          marginBottom: '4px',
-        }}>
-          {node.type}
-        </div>
-        <div style={{ 
-          fontSize: '10px', 
-          color: '#999',
-        }}>
-          {node.path}
-        </div>
-      </div>
-
-      {/* State indicator */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '6px',
-          fontSize: '11px',
-          marginTop: '6px',
-        }}
-      >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+        {/* Top Row: Cook Circle | Node Glyph | Node Type */}
         <div
           style={{
-            width: '8px',
-            height: '8px',
-            borderRadius: '50%',
-            background: stateColor,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '8px',
           }}
-        />
-        <span style={{ color: '#666' }}>{node.state}</span>
+        >
+          {/* Cooking color circle (left) */}
+          <div
+            style={{
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+              background: stateColor,
+              flexShrink: 0,
+            }}
+          />
+
+          {/* Node glyph (middle) */}
+          <div
+            style={{
+              fontSize: '18px',
+              fontWeight: 'bold',
+              flex: 1,
+              textAlign: 'center',
+            }}
+          >
+            {node.glyph || '?'}
+          </div>
+
+          {/* Node type (right) */}
+          <div
+            style={{
+              fontSize: '11px',
+              color: '#666',
+              fontWeight: '500',
+              flexShrink: 0,
+            }}
+          >
+            {node.type}
+          </div>
+        </div>
+
+        {/* Bottom Row: Node Name (centered) */}
+        <div
+          style={{
+            fontSize: '12px',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            color: '#333',
+          }}
+        >
+          {node.name}
+        </div>
       </div>
 
       {/* Output handles */}

--- a/src/GUI/src/types.ts
+++ b/src/GUI/src/types.ts
@@ -26,6 +26,7 @@ export interface NodeResponse {
   name: string;
   path: string;
   type: string;
+  glyph: string;
   state: string;
   parameters: Record<string, ParameterInfo>;
   inputs: InputInfo[];

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -155,7 +155,8 @@ class NodeResponse(BaseModel):
     name: str = Field(..., description="Node name (may not be unique)")
     path: str = Field(..., description="Full path (unique identifier)")
     type: str = Field(..., description="Node type (e.g., 'text', 'fileout', 'query')")
-    
+    glyph: str = Field(default="", description="Node type glyph character")
+
     # Processing state
     state: NodeStateEnum = Field(..., description="Current processing state")
     errors: List[str] = Field(default_factory=list, description="Critical error messages")
@@ -477,6 +478,7 @@ def node_to_response(node: 'Node') -> 'NodeResponse':
             name=node.name(),
             path=node.path(),
             type=node.type().value,  # Use enum's value directly
+            glyph=getattr(node.__class__, 'GLYPH', ''),  # Get GLYPH class attribute
             state=full_state.state.value,
             errors=full_state.errors,
             warnings=full_state.warnings,


### PR DESCRIPTION
Updates the GUI node display to show less information in a more organized way:
- Top row: cooking status circle (left), node type glyph (center), node type (right)
- Bottom row: node name (centered)

Removed the path and state text display to reduce clutter.

Backend changes:
- Add glyph field to NodeResponse model
- Extract GLYPH class attribute in node_to_response()

Frontend changes:
- Add glyph field to NodeResponse interface
- Redesign CustomNode component with new two-row layout