### PR TITLE
Fix GUI node renaming not updating display

### DIFF
--- a/src/GUI/src/NodeDetailsPanel.tsx
+++ b/src/GUI/src/NodeDetailsPanel.tsx
@@ -6,12 +6,14 @@ import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import type { NodeResponse } from './types';
+import { useWorkspace } from './WorkspaceContext';
 
 interface NodeDetailsPanelProps {
   node: NodeResponse | null;
 }
 
 export const NodeDetailsPanel: React.FC<NodeDetailsPanelProps> = ({ node }) => {
+  const { updateNode } = useWorkspace();
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [nameError, setNameError] = useState('');
@@ -61,11 +63,8 @@ export const NodeDetailsPanel: React.FC<NodeDetailsPanelProps> = ({ node }) => {
     }
 
     try {
-      // Import apiClient dynamically to avoid circular dependencies
-      const { apiClient } = await import('./apiClient');
-
-      // Call the API to rename the node
-      await apiClient.updateNode(node.session_id, { name: trimmedName });
+      // Call the workspace context to update the node (updates both API and local state)
+      await updateNode(node.session_id, { name: trimmedName });
 
       // Success - exit edit mode
       setIsEditing(false);

--- a/src/core/mobile_item.py
+++ b/src/core/mobile_item.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum, auto
+import re
 import uuid
 from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 from core.enums import NetworkItemType


### PR DESCRIPTION
Fixed two critical issues preventing node renaming in the GUI:

1. Backend: Added missing `import re` in src/core/mobile_item.py:3
   - The set_name() method at line 83 uses re.search() but the import was missing
   - This caused a NameError when attempting to rename nodes

2. Frontend: Updated NodeDetailsPanel to use WorkspaceContext.updateNode()
   - Previously called apiClient.updateNode() directly, bypassing workspace state management
   - Now uses the context's updateNode() method which updates both API and local state
   - This ensures the UI refreshes immediately after renaming

The rename functionality now properly updates both backend and frontend state.