### PR TITLE
Implement Phase 3.1 GUI features

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -35,7 +35,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onSelectionChange }) =
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
+  const [_isDragging, setIsDragging] = useState(false);
   const [draggedNodeIds, setDraggedNodeIds] = useState<Set<string>>(new Set());
 
   // Wrapped onNodesChange to prevent deselection after drag

--- a/src/GUI/src/apiClient.ts
+++ b/src/GUI/src/apiClient.ts
@@ -5,7 +5,10 @@ import type {
   ApiError,
   NodeResponse,
   NodeCreateRequest,
-  NodeUpdateRequest
+  NodeUpdateRequest,
+  ConnectionRequest,
+  ConnectionResponse,
+  ConnectionDeleteRequest
 } from './types';
 
 const API_BASE_URL = 'http://localhost:8000/api/v1';
@@ -72,6 +75,21 @@ class ApiClient {
 
   async listNodes(): Promise<NodeResponse[]> {
     return this.fetchJson<NodeResponse[]>('/nodes');
+  }
+
+  // Connection operations
+  async createConnection(request: ConnectionRequest): Promise<ConnectionResponse> {
+    return this.fetchJson<ConnectionResponse>('/connections', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
+  async deleteConnection(request: ConnectionDeleteRequest): Promise<void> {
+    await this.fetchJson<void>('/connections', {
+      method: 'DELETE',
+      body: JSON.stringify(request),
+    });
   }
 }
 

--- a/src/GUI/src/types.ts
+++ b/src/GUI/src/types.ts
@@ -77,3 +77,18 @@ export interface NodeUpdateRequest {
   position?: [number, number];
   color?: [number, number, number];
 }
+
+// Request types for connection operations
+export interface ConnectionRequest {
+  source_node_path: string;
+  source_output_index: number;
+  target_node_path: string;
+  target_input_index: number;
+}
+
+export interface ConnectionDeleteRequest {
+  source_node_path: string;
+  source_output_index: number;
+  target_node_path: string;
+  target_input_index: number;
+}


### PR DESCRIPTION
Add foundational TypeScript infrastructure for connection management:
- Add ConnectionRequest and ConnectionDeleteRequest types to types.ts
- Add createConnection() and deleteConnection() methods to apiClient
- Update apiClient imports to include new connection types
- Fix unused variable warning in GraphCanvas.tsx

This phase adds no UI changes, only the type definitions and API methods that will be used in later phases for connection management.

Relates to Phase 3.1 implementation as documented in src/GUI/phase_3_1_foundation.md