### PR TITLE
Add persistent session IDs to connections

### DIFF
--- a/src/GUI/src/apiClient.ts
+++ b/src/GUI/src/apiClient.ts
@@ -91,6 +91,12 @@ class ApiClient {
       body: JSON.stringify(request),
     });
   }
+
+  async deleteConnectionById(connectionId: string): Promise<void> {
+    await this.fetchJson<void>(`/connections/${connectionId}`, {
+      method: 'DELETE',
+    });
+  }
 }
 
 export const apiClient = new ApiClient();

--- a/src/GUI/src/types.ts
+++ b/src/GUI/src/types.ts
@@ -41,6 +41,7 @@ export interface NodeResponse {
 }
 
 export interface ConnectionResponse {
+  connection_id: string;
   source_node_session_id: string;
   source_node_path: string;
   source_output_index: number;

--- a/src/GUI/src/utils/edgeMapping.ts
+++ b/src/GUI/src/utils/edgeMapping.ts
@@ -6,8 +6,7 @@ import type { ConnectionResponse } from '../types';
 /**
  * Convert ConnectionResponse from backend to React Flow Edge format
  *
- * Creates a unique edge ID using all 4 identifying components:
- * {source_node_session_id}-{source_output_index}-{target_node_session_id}-{target_input_index}
+ * Uses the connection's session ID directly as the edge ID.
  *
  * Maps backend indices to React Flow handle IDs:
  * - source_output_index: 0 → sourceHandle: "output-0"
@@ -15,7 +14,7 @@ import type { ConnectionResponse } from '../types';
  */
 export function connectionToEdge(connection: ConnectionResponse): Edge {
   return {
-    id: `${connection.source_node_session_id}-${connection.source_output_index}-${connection.target_node_session_id}-${connection.target_input_index}`,
+    id: connection.connection_id,
     source: connection.source_node_session_id,
     target: connection.target_node_session_id,
     sourceHandle: `output-${connection.source_output_index}`,

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -222,9 +222,10 @@ class NodeUpdateRequest(BaseModel):
 class ConnectionResponse(BaseModel):
     """
     A connection between two nodes.
-    
+
     Example:
         {
+            "connection_id": "123e4567-e89b-12d3-a456-426614174000",
             "source_node_session_id": 123456,
             "source_node_path": "/text1",
             "source_output_index": 0,
@@ -235,12 +236,15 @@ class ConnectionResponse(BaseModel):
             "target_input_name": "input"
         }
     """
+    # Unique connection identifier
+    connection_id: str = Field(..., description="Unique connection session ID")
+
     # Source (output) side
     source_node_session_id: str = Field(..., description="Source node's session ID")
     source_node_path: str = Field(..., description="Source node's path")
     source_output_index: int = Field(..., description="Output socket index")
     source_output_name: str = Field(..., description="Output socket name")
-    
+
     # Target (input) side
     target_node_session_id: str = Field(..., description="Target node's session ID")
     target_node_path: str = Field(..., description="Target node's path")
@@ -513,14 +517,15 @@ def node_to_response(node: 'Node') -> 'NodeResponse':
 def connection_to_response(connection: 'NodeConnection') -> ConnectionResponse:
     """
     Convert an internal NodeConnection to a ConnectionResponse DTO.
-    
+
     Args:
         connection: Internal NodeConnection instance
-        
+
     Returns:
         ConnectionResponse with connection details
     """
     return ConnectionResponse(
+        connection_id=connection.session_id(),
         source_node_session_id=connection.output_node().session_id(),
         source_node_path=connection.output_node().path(),
         source_output_index=connection.output_index(),

--- a/test_connection_session_ids.py
+++ b/test_connection_session_ids.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Quick test to verify NodeConnection session ID functionality.
+"""
+
+import sys
+sys.path.insert(0, 'src')
+
+from core.base_classes import NodeEnvironment
+from core.node_connection import NodeConnection
+from core.node import Node
+from core.enums import NodeType
+
+
+def test_connection_session_ids():
+    """Test that connections get unique session IDs."""
+    print("Testing NodeConnection session ID functionality...")
+
+    # Create some test nodes
+    text_node = Node.create_node(NodeType.TEXT, node_name="test_text")
+    fileout_node = Node.create_node(NodeType.FILE_OUT, node_name="test_fileout")
+
+    print(f"✓ Created nodes: {text_node.path()} and {fileout_node.path()}")
+
+    # Create a connection
+    fileout_node.set_input(0, text_node, 0)
+    connection = fileout_node._inputs[0]
+
+    print(f"✓ Created connection with session_id: {connection.session_id()}")
+
+    # Verify the session ID exists and is a string
+    assert connection.session_id() is not None
+    assert isinstance(connection.session_id(), str)
+    assert len(connection.session_id()) > 0
+    print(f"✓ Session ID is valid: {connection.session_id()}")
+
+    # Create another connection and verify it has a different ID
+    text_node2 = Node.create_node(NodeType.TEXT, node_name="test_text2")
+    fileout_node2 = Node.create_node(NodeType.FILE_OUT, node_name="test_fileout2")
+    fileout_node2.set_input(0, text_node2, 0)
+    connection2 = fileout_node2._inputs[0]
+
+    print(f"✓ Created second connection with session_id: {connection2.session_id()}")
+
+    # Verify IDs are different
+    assert connection.session_id() != connection2.session_id()
+    print(f"✓ Session IDs are unique")
+
+    # Verify IDs are tracked in the class variable
+    assert connection.session_id() in NodeConnection._existing_session_ids
+    assert connection2.session_id() in NodeConnection._existing_session_ids
+    print(f"✓ Session IDs are tracked in class variable")
+
+    # Test __repr__
+    repr_str = repr(connection)
+    assert "session_id=" in repr_str
+    assert connection.session_id() in repr_str
+    print(f"✓ __repr__ includes session_id: {repr_str[:80]}...")
+
+    print("\n✅ All tests passed!")
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        test_connection_session_ids()
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
This change makes connections first-class entities with stable identifiers, simplifying frontend code and enabling future features.

Backend changes:
- Add session_id property to NodeConnection with UUID generation
- Track all connection IDs in class-level set for uniqueness
- Add cleanup in __del__ to remove IDs from tracking set
- Update __repr__ to include session_id

API changes:
- Add connection_id field to ConnectionResponse model
- Update connection_to_response() to include session_id
- Add new DELETE /connections/{connection_id} endpoint
- Keep old DELETE endpoint for backward compatibility

Frontend changes:
- Add connection_id to ConnectionResponse TypeScript interface
- Add deleteConnectionById() method to apiClient
- Update edgeMapping to use connection_id as React Flow edge ID
- Simplify GraphCanvas onConnect to use backend connection_id
- Simplify GraphCanvas onEdgesDelete to use ID-based deletion

Benefits:
- No more manual edge ID generation or handle parsing in delete handler
- More robust - no string parsing, no NaN bugs
- Consistent pattern with node session IDs
- Cleaner, more maintainable code (~50% reduction in delete handler)

Test coverage:
- Add test_connection_session_ids.py to verify UUID generation, uniqueness, and tracking