### PR TITLE
Fix API 422 error in connection workflow

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -228,11 +228,11 @@ class ConnectionResponse(BaseModel):
             "connection_id": "123e4567-e89b-12d3-a456-426614174000",
             "source_node_session_id": 123456,
             "source_node_path": "/text1",
-            "source_output_index": 0,
+            "source_output_index": "output",
             "source_output_name": "output",
             "target_node_session_id": 789012,
             "target_node_path": "/fileout1",
-            "target_input_index": 0,
+            "target_input_index": "input",
             "target_input_name": "input"
         }
     """
@@ -242,50 +242,50 @@ class ConnectionResponse(BaseModel):
     # Source (output) side
     source_node_session_id: str = Field(..., description="Source node's session ID")
     source_node_path: str = Field(..., description="Source node's path")
-    source_output_index: int = Field(..., description="Output socket index")
+    source_output_index: Union[int, str] = Field(..., description="Output socket index (can be int or string)")
     source_output_name: str = Field(..., description="Output socket name")
 
     # Target (input) side
     target_node_session_id: str = Field(..., description="Target node's session ID")
     target_node_path: str = Field(..., description="Target node's path")
-    target_input_index: int = Field(..., description="Input socket index")
+    target_input_index: Union[int, str] = Field(..., description="Input socket index (can be int or string)")
     target_input_name: str = Field(..., description="Input socket name")
 
 
 class ConnectionRequest(BaseModel):
     """
     Request to create a connection between two nodes.
-    
+
     Example:
         {
             "source_node_path": "/text1",
-            "source_output_index": 0,
+            "source_output_index": "output",
             "target_node_path": "/fileout1",
-            "target_input_index": 0
+            "target_input_index": "input"
         }
     """
     source_node_path: str = Field(..., description="Source node path")
-    source_output_index: int = Field(default=0, description="Output socket index")
+    source_output_index: Union[int, str] = Field(default=0, description="Output socket index (can be int or string)")
     target_node_path: str = Field(..., description="Target node path")
-    target_input_index: int = Field(default=0, description="Input socket index")
+    target_input_index: Union[int, str] = Field(default=0, description="Input socket index (can be int or string)")
 
 
 class ConnectionDeleteRequest(BaseModel):
     """
     Request to delete a specific connection.
-    
+
     Example:
         {
             "source_node_path": "/text1",
-            "source_output_index": 0,
+            "source_output_index": "output",
             "target_node_path": "/fileout1",
-            "target_input_index": 0
+            "target_input_index": "input"
         }
     """
     source_node_path: str = Field(..., description="Source node path")
-    source_output_index: int = Field(..., description="Output socket index")
+    source_output_index: Union[int, str] = Field(..., description="Output socket index (can be int or string)")
     target_node_path: str = Field(..., description="Target node path")
-    target_input_index: int = Field(..., description="Input socket index")
+    target_input_index: Union[int, str] = Field(..., description="Input socket index (can be int or string)")
 
 
 # ============================================================================

--- a/src/core/node_connection.py
+++ b/src/core/node_connection.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 import uuid
 from .enums import NetworkItemType
 from .network_entity import NetworkEntity
@@ -17,12 +17,13 @@ class NodeConnection(NetworkEntity):
     _existing_session_ids: Set[str] = set()
 
     def __init__(self, output_node: 'Node', input_node: 'Node',
-        output_index: int, input_index: int):
+        output_index: Union[int, str], input_index: Union[int, str]):
         super().__init__()
         self._output_node: 'Node' = output_node
         self._input_node: 'Node' = input_node
-        self._output_index: int = output_index
-        self._input_index: int = input_index
+        # Store indices as-is (can be int or str depending on node type)
+        self._output_index: Union[int, str] = output_index
+        self._input_index: Union[int, str] = input_index
         self._selected: bool = False
 
         # Generate unique session ID for this connection
@@ -36,11 +37,11 @@ class NodeConnection(NetworkEntity):
         """Returns the node on the input side of this connection."""
         return self._input_node
 
-    def output_index(self) ->int:
+    def output_index(self) -> Union[int, str]:
         """Returns the index of the output connection on the output node."""
         return self._output_index
 
-    def input_index(self) ->int:
+    def input_index(self) -> Union[int, str]:
         """Returns the index of the input connection on the input node."""
         return self._input_index
 


### PR DESCRIPTION
The API was failing with a 422 validation error when creating connections because:
1. Some nodes (like TextNode) use string indices ("input", "output") instead of integer indices (0, 1, 2)
2. ConnectionResponse and ConnectionRequest models only accepted int indices
3. Pydantic validation rejected responses with string indices

Changes:
- Updated ConnectionResponse model to accept Union[int, str] for all index fields
- Updated ConnectionRequest model to accept Union[int, str] for index fields
- Updated ConnectionDeleteRequest model to accept Union[int, str] for indices
- Updated NodeConnection.__init__ to accept Union[int, str] for indices
- Updated NodeConnection.output_index() and input_index() return types
- Fixed index validation in connections router to handle both int and string indices
- Added proper validation logic that checks string indices against input_names/output_names keys

This fix allows connections to be created between nodes regardless of whether they use integer or string socket indices, resolving the 422 error.