### PR TITLE
Fix looper node display and connection issues

### DIFF
--- a/src/GUI/src/LoopBoundary.tsx
+++ b/src/GUI/src/LoopBoundary.tsx
@@ -83,7 +83,7 @@ export const LoopBoundary: React.FC<LoopBoundaryProps> = ({ nodes, padding = DEF
         width: '100%',
         height: '100%',
         pointerEvents: 'none',
-        zIndex: -1,
+        zIndex: 0,
       }}
     >
       <path

--- a/src/GUI/src/looperTransform.ts
+++ b/src/GUI/src/looperTransform.ts
@@ -100,7 +100,7 @@ function createLooperEndNode(system: LooperSystem): NodeResponse {
     ...outputNullNode,
     session_id: createTransformedId(looperNode.session_id, LOOPER_END_SUFFIX),
     name: createTransformedId(looperNode.name, LOOPER_END_SUFFIX),
-    glyph: '◁',
+    glyph: '⟲◁',
     type: 'looper_end',
     position: [x + (NODE_WIDTH * 2), y],
   };


### PR DESCRIPTION
- Fix polygon overlay z-index from -1 to 0 so it displays above background
- Transform connection node IDs to map inputNull/outputNull to looper_start/looper_end
- Add arrow circle glyph (⟲) to looper_end node display
- Ensure connection wires properly display for looper node connections

Fixes issues where:
1. Polygon boundary was rendering behind workspace
2. Connection wires to looper_end were not showing
3. Connection wires from looper_start output were not showing and output circle was grey
4. Looper_end was missing the arrow circle glyph