### PR TITLE
Fix looper polygon coverage and make it dynamic

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -329,12 +329,15 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onSelectionChange }) =
       >
         <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
         <Controls />
-        {Array.from(looperSystems.values()).map(system => (
-          <LoopBoundary
-            key={system.looperNode.session_id}
-            nodes={gatherBoundaryNodes(system, workspaceNodes, nodes)}
-          />
-        ))}
+        {Array.from(looperSystems.values()).map(system => {
+          const transformedConnections = transformConnectionNodeIds(connections, looperSystems);
+          return (
+            <LoopBoundary
+              key={system.looperNode.session_id}
+              nodes={gatherBoundaryNodes(system, workspaceNodes, nodes, transformedConnections)}
+            />
+          );
+        })}
       </ReactFlow>
     </>
   );

--- a/src/GUI/src/LoopBoundary.tsx
+++ b/src/GUI/src/LoopBoundary.tsx
@@ -42,19 +42,27 @@ interface LoopBoundaryProps {
   padding?: number;
 }
 
-const NODE_WIDTH = 150;
-const NODE_HEIGHT = 60;
+const DEFAULT_NODE_WIDTH = 180;
+const DEFAULT_NODE_HEIGHT = 80;
 const DEFAULT_PADDING = 30;
+
+function getNodeDimensions(node: Node): { width: number; height: number } {
+  return {
+    width: node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH,
+    height: node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT,
+  };
+}
 
 function extractBoundingBoxCorners(nodes: Node[]): Point[] {
   const corners: Point[] = [];
   nodes.forEach(node => {
     const { x, y } = node.position;
+    const { width, height } = getNodeDimensions(node);
     corners.push(
       { x, y },
-      { x: x + NODE_WIDTH, y },
-      { x, y: y + NODE_HEIGHT },
-      { x: x + NODE_WIDTH, y: y + NODE_HEIGHT }
+      { x: x + width, y },
+      { x, y: y + height },
+      { x: x + width, y: y + height }
     );
   });
   return corners;


### PR DESCRIPTION
The looper polygon now properly covers looper_start and looper_end nodes by using actual measured dimensions instead of hardcoded values. Additionally, the polygon dynamically expands to include any nodes connected to looper_start outputs or looper_end inputs.