### PR TITLE
Write clean, maintainable code with best practices

### DIFF
--- a/src/GUI/src/NodeDetailsPanel.tsx
+++ b/src/GUI/src/NodeDetailsPanel.tsx
@@ -9,6 +9,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import type { NodeResponse } from './types';
 import { useWorkspace } from './WorkspaceContext';
 import { ParameterEditor } from './ParameterEditor';
+import { getOriginalNodeId, isLooperPart } from './looperTransform';
 
 interface NodeDetailsPanelProps {
   node: NodeResponse | null;
@@ -117,8 +118,9 @@ export const NodeDetailsPanel: React.FC<NodeDetailsPanelProps> = ({ node }) => {
 
   const handleParameterChange = useCallback(async (paramName: string, value: string | number | boolean | string[]) => {
     if (!node) return;
+    const targetNodeId = isLooperPart(node.type) ? getOriginalNodeId(node.session_id) : node.session_id;
     try {
-      await updateNode(node.session_id, {
+      await updateNode(targetNodeId, {
         parameters: {
           [paramName]: value,
         },

--- a/src/GUI/src/looperTransform.ts
+++ b/src/GUI/src/looperTransform.ts
@@ -98,12 +98,14 @@ function createLooperEndNode(system: LooperSystem): NodeResponse {
   const [x, y] = looperNode.position;
 
   return {
-    ...outputNullNode,
+    ...looperNode,
     session_id: createTransformedId(looperNode.session_id, LOOPER_END_SUFFIX),
     name: createTransformedId(looperNode.name, LOOPER_END_SUFFIX),
     glyph: '⟲◁',
     type: 'looper_end',
     position: [x + (NODE_WIDTH * 2), y],
+    inputs: outputNullNode.inputs,
+    outputs: outputNullNode.outputs,
   };
 }
 


### PR DESCRIPTION
Looper_Start and Looper_End now correctly reference base looper parameters. createLooperEndNode inherits from looperNode instead of outputNullNode. Parameter updates resolve to original node ID via getOriginalNodeId.