### PR TITLE
various fixes to null_node and looper in the GUI

### DIFF
--- a/src/GUI/src/App.tsx
+++ b/src/GUI/src/App.tsx
@@ -22,6 +22,7 @@ import { NodeDetailsPanel } from './NodeDetailsPanel';
 import { GlobalsPanel } from './GlobalsPanel';
 import { AddNodeMenu } from './AddNodeMenu';
 import { OutputPanel } from './OutputPanel';
+import { transformLooperNodes, getOriginalNodeId } from './looperTransform';
 
 const AppContent: React.FC = () => {
   const { loadWorkspace, loading, error, nodes, lastExecutionResult, lastExecutedNodeName, clearExecutionResult } = useWorkspace();
@@ -33,9 +34,18 @@ const AppContent: React.FC = () => {
     loadWorkspace();
   }, [loadWorkspace]);
 
-  // Get the selected node's full data from workspace
   const selectedNode = selectedNodes.length === 1
-    ? nodes.find(n => n.session_id === selectedNodes[0].id) || null
+    ? (() => {
+        const selectedId = selectedNodes[0].id;
+        const baseId = getOriginalNodeId(selectedId);
+        const node = nodes.find(n => n.session_id === baseId);
+
+        if (!node) return null;
+        if (baseId === selectedId) return node;
+
+        const { displayNodes } = transformLooperNodes(nodes);
+        return displayNodes.find(n => n.session_id === selectedId) || null;
+      })()
     : null;
 
   return (

--- a/src/core/null_node.py
+++ b/src/core/null_node.py
@@ -17,13 +17,19 @@ class NullNode(Node):
         super().__init__(name, path, position, node_type)
         self._input_value: Optional[List[str]] = None
 
+    def input_names(self) -> Dict[int, str]:
+        return {0: "Input"}
+
+    def output_names(self) -> Dict[int, str]:
+        return {0: "Output"}
+
     def _internal_cook(self, force: bool = False) -> None:
         self.set_state(NodeState.COOKING)
         try:
             if self.inputs():
                 input_connection = self.inputs()[0]
-                input_data = input_connection.output_node().eval(requesting_node=self)  
-                
+                input_data = input_connection.output_node().eval(requesting_node=self)
+
                 if isinstance(input_data, list) and all(isinstance(item, str) for item in input_data):
                     self._input_value = input_data
                     self._output = input_data  # Add this line to set the output
@@ -32,7 +38,7 @@ class NullNode(Node):
             else:
                 self._input_value = []
                 self._output = []  # Add this line to set empty output
-            
+
             self.set_state(NodeState.UNCHANGED)
 
         except Exception as e:


### PR DESCRIPTION
NullNode now declares its input and output ports via input_names() and output_names() methods, enabling the frontend to render connection circles.

Fixed NodeDetailsPanel to properly resolve looper part nodes (Looper_Start and Looper_End) to their transformed representations, ensuring parameters from the underlying LooperNode are displayed when these nodes are selected.