### PR TITLE
Fix missing connection wire in looper node

### DIFF
--- a/src/GUI/src/looperTransform.ts
+++ b/src/GUI/src/looperTransform.ts
@@ -99,6 +99,7 @@ function createLooperEndNode(system: LooperSystem): NodeResponse {
 
   return {
     ...looperNode,
+    path: outputNullNode.path,
     session_id: createTransformedId(looperNode.session_id, LOOPER_END_SUFFIX),
     name: createTransformedId(looperNode.name, LOOPER_END_SUFFIX),
     glyph: '⟲◁',


### PR DESCRIPTION
This mirrors the fix from commit 73ced98 for Looper_Start. By explicitly setting path: outputNullNode.path in createLooperEndNode, connections to/from Looper_End now use the correct backend node reference (outputNullNode), allowing transformConnectionNodeIds() to properly map them to the display ID format (looper_X_end).

Without this fix, Looper_End inherited looperNode.path, causing connection wires from node outputs to Looper_End inputs to be stored with the wrong path and not display correctly.

Fixes the missing connection wire from text_1 output to Looper_End input.