### PR TITLE
Write clean, maintainable code with best practices

### DIFF
--- a/src/GUI/src/NodeDetailsPanel.tsx
+++ b/src/GUI/src/NodeDetailsPanel.tsx
@@ -40,9 +40,11 @@ export const NodeDetailsPanel: React.FC<NodeDetailsPanelProps> = ({ node }) => {
   const handleCook = useCallback(async () => {
     if (isExecuting || !node) return;
 
+    const targetNodeId = isLooperPart(node.type) ? getOriginalNodeId(node.session_id) : node.session_id;
+
     setIsExecuting(true);
     try {
-      await executeNode(node.session_id);
+      await executeNode(targetNodeId);
     } catch (error) {
       console.error('Failed to execute node:', error);
     } finally {


### PR DESCRIPTION
When cooking looper_start or looper_end nodes, resolve their session_id to the original looper node's session_id before executing. This prevents 404 errors since the API only recognizes the base looper node, not the transformed GUI representations.