### PR TITLE
Fix sticky parameter window bug

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -71,6 +71,9 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
     const transformedConnections = transformConnectionNodeIds(connections, systems);
     const enrichedNodes = enrichNodesWithConnectionState(displayNodes, transformedConnections);
 
+    // Preserve current selection state when recreating nodes
+    const currentlySelectedIds = new Set(nodes.filter(n => n.selected).map(n => n.id));
+
     const newNodes = enrichedNodes.map((node: NodeResponse) => {
       const nodeId = String(node.session_id);
 
@@ -79,8 +82,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
         type: 'custom',
         position: { x: node.position[0], y: node.position[1] },
         data: { node },
-        // Auto-select newly created nodes for immediate interaction
-        selected: nodeId === newlyCreatedNodeId,
+        // Preserve selection state or auto-select newly created nodes
+        selected: nodeId === newlyCreatedNodeId || currentlySelectedIds.has(nodeId),
       };
     });
 
@@ -93,7 +96,7 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
         onNodeFocus(newNode);
       }
     }
-  }, [workspaceNodes, connections, setNodes, newlyCreatedNodeId, onNodeFocus]);
+  }, [workspaceNodes, connections, setNodes, newlyCreatedNodeId, onNodeFocus, nodes]);
 
   useEffect(() => {
     const transformedConnections = transformConnectionNodeIds(connections, looperSystems);


### PR DESCRIPTION
Problem:
- Parameter window stayed stuck on first selected node
- Selecting a different node didn't update the parameter window
- Caused by commit 60bec9fa which made it "too sticky"

Root Cause:
- When nodes were recreated (after parameter updates), all nodes got selected: false
- This broke React Flow's selection tracking
- React Flow couldn't detect when user selected a different node
- Selection change events weren't triggered properly

Solution:
- Preserve current selection state when recreating nodes
- Capture currently selected node IDs before recreation
- Restore selection state to those same nodes after recreation
- Add nodes to useEffect dependency array (required for reading selection state)

Changes:
- GraphCanvas.tsx: Preserve selection with currentlySelectedIds Set
- GraphCanvas.tsx: Restore selection in node mapping
- GraphCanvas.tsx: Add nodes to useEffect dependencies

Now:
- Selecting Node A shows Node A in parameter window
- Changing Node A parameters keeps Node A selected and focused
- Clicking Node B properly updates parameter window to show Node B
- React Flow can track selection changes correctly

Fixes issue reported after commit #55 (60bec9fa)