### PR TITLE
Brighten node bypass grey color

### DIFF
--- a/src/GUI/src/CustomNode.tsx
+++ b/src/GUI/src/CustomNode.tsx
@@ -30,12 +30,14 @@ interface IndicatorCircleProps {
   color: string;
   title: string;
   diameter?: number;
+  outlineColor?: string;
 }
 
 const IndicatorCircle: React.FC<IndicatorCircleProps> = ({
   color,
   title,
-  diameter = design.ERROR_WARNING_DIAMETER
+  diameter = design.ERROR_WARNING_DIAMETER,
+  outlineColor
 }) => (
   <div
     style={{
@@ -43,6 +45,9 @@ const IndicatorCircle: React.FC<IndicatorCircleProps> = ({
       height: `${diameter}px`,
       borderRadius: '50%',
       background: color,
+      boxShadow: outlineColor
+        ? `0 0 0 2px ${color}, 0 0 0 4px ${outlineColor}`
+        : undefined,
     }}
     title={title}
   />
@@ -156,6 +161,7 @@ export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> 
           <IndicatorCircle
             color={design.COLOR_ERROR}
             title="Has errors"
+            outlineColor={design.COLOR_ERROR_OUTLINE}
           />
         )}
 
@@ -163,6 +169,7 @@ export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> 
           <IndicatorCircle
             color={design.COLOR_WARNING}
             title="Has warnings"
+            outlineColor={design.COLOR_WARNING_OUTLINE}
           />
         )}
       </div>

--- a/src/GUI/src/nodeDesign.ts
+++ b/src/GUI/src/nodeDesign.ts
@@ -41,10 +41,12 @@ export const COLOR_COOKING_UNCHANGED = '#4caf50';
 export const COLOR_COOKING_COOKING = '#2196f3';
 
 export const COLOR_ERROR = '#A855F7';
+export const COLOR_ERROR_OUTLINE = '#E0C4EC';
 export const COLOR_WARNING = '#FCD34D';
+export const COLOR_WARNING_OUTLINE = '#F2E8C4';
 
-export const COLOR_BYPASS_DEFAULT = '#6B7280';
-export const COLOR_BYPASS_HOVER = '#9CA3AF';
+export const COLOR_BYPASS_DEFAULT = '#CED0D5';
+export const COLOR_BYPASS_HOVER = '#E5E7EB';
 
 export const COLOR_TEXT_ACTIVE = '#1F2937';
 export const COLOR_TEXT_BYPASSED = '#4B5563';


### PR DESCRIPTION
- Make bypass circle 3x brighter (proportionally): #6B7280 → #CED0D5
- Update hover state to match new brightness level
- Add 2px inner border (active color) to error/warning circles
- Add 2px outer border (dim color) to error/warning circles
- Dim outline colors are 50% saturation and 50% whiter than active state
- Error outline: #E0C4EC
- Warning outline: #F2E8C4