### PR TITLE
Debug GUI crash from recent commits

### DIFF
--- a/src/GUI/src/theme.ts
+++ b/src/GUI/src/theme.ts
@@ -1,4 +1,5 @@
-import { createTheme, Theme } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
 
 export const lightTheme: Theme = createTheme({
   palette: {


### PR DESCRIPTION
The Theme type was incorrectly imported as a value, causing a SyntaxError at runtime. In MUI v5, Theme is a TypeScript type and must be imported using 'import type' syntax.

This fixes the white screen crash with error:
"The requested module doesn't provide an export named: 'Theme'"

Fixes introduced in commit 7593e1a