### PR TITLE
Fix node name text entry not updating

### DIFF
--- a/src/GUI/src/App.tsx
+++ b/src/GUI/src/App.tsx
@@ -35,7 +35,7 @@ import { useTheme } from './ThemeContext';
 
 const AppContent: React.FC = () => {
   const { mode, toggleTheme } = useTheme();
-  const { loadWorkspace, loading, error, lastExecutionResult, lastExecutedNodeName, clearExecutionResult } = useWorkspace();
+  const { nodes, loadWorkspace, loading, error, lastExecutionResult, lastExecutedNodeName, clearExecutionResult } = useWorkspace();
   const { save, saveAs, open, newWorkspace, isDirty, markClean } = useFileManager();
   const [focusedNode, setFocusedNode] = useState<NodeResponse | null>(null);
   const [activeTab, setActiveTab] = useState<'details' | 'globals'>('details');
@@ -70,6 +70,19 @@ const AppContent: React.FC = () => {
 
     checkAutosave();
   }, [loadWorkspace]);
+
+  // Sync focusedNode with updated node data
+  useEffect(() => {
+    if (focusedNode) {
+      const updatedNode = nodes.find(n => n.session_id === focusedNode.session_id);
+      if (updatedNode && updatedNode !== focusedNode) {
+        setFocusedNode(updatedNode);
+      } else if (!updatedNode) {
+        // Node was deleted
+        setFocusedNode(null);
+      }
+    }
+  }, [nodes, focusedNode]);
 
   // Handle autosave recovery
   const handleRecoverAutosave = useCallback(async () => {


### PR DESCRIPTION
Previously, when a user edited a node name in the NodeDetailsPanel, the change wouldn't reflect in the parameter window. This was because the focusedNode state in App.tsx held a reference to the old node object and wasn't updated when the node was updated via the API.

This fix adds a useEffect that syncs focusedNode with the updated node data from the WorkspaceContext's nodes array whenever it changes. This ensures that NodeDetailsPanel always receives the latest node data.

The fix also handles the case where a focused node is deleted, setting focusedNode to null in that scenario.