### PR TITLE
Add right parenthesis to text separators in both places

### DIFF
--- a/src/core/make_list_node.py
+++ b/src/core/make_list_node.py
@@ -27,7 +27,7 @@ class MakeListNode(Node):
             * Written numbers (one., two., three.)
             * Ordinal numbers (first., second., third.)
             * Compound numbers (twenty-one, ninety-nine)
-        - Handles various separators between numbers and text (. : - _)
+        - Handles various separators between numbers and text (. : - _ ))
         - Preserves multi-line list items
         - Maintains original text formatting within list items
         - Case-insensitive number word recognition

--- a/src/core/text_utils.py
+++ b/src/core/text_utils.py
@@ -69,7 +69,7 @@ def parse_list(text):
             - Written numbers (one., two., three.)
             - Ordinal numbers (first., second., third.)
             - Compound numbers (twenty-one, ninety-nine)
-            - Separators: . : - _
+            - Separators: . : - _ )
             - Case-insensitive number word recognition
             - Multi-line list items preserved
 
@@ -116,7 +116,7 @@ def parse_list(text):
     lines = text.split('\n')
 
     start_index = next((i for i, line in enumerate(lines)
-                        if re.match(r'^(\d+|{word_pattern})([.:\-_]?\s)'.format(word_pattern=number_word_pattern),
+                        if re.match(r'^(\d+|{word_pattern})([.:\-_)]?\s)'.format(word_pattern=number_word_pattern),
                                     line.strip(), flags=re.IGNORECASE)),None)
 
     if start_index is None:
@@ -125,10 +125,10 @@ def parse_list(text):
     processed_items = []
     current_item = ""
     for line in lines[start_index:]:
-        clean_line = re.sub(r'^(\d+|{word_pattern})([.:\-_]?\s)'.format(word_pattern=number_word_pattern), '',
+        clean_line = re.sub(r'^(\d+|{word_pattern})([.:\-_)]?\s)'.format(word_pattern=number_word_pattern), '',
                             line.strip(), flags=re.IGNORECASE)
 
-        if re.match(r'^(\d+|{word_pattern})([.:\-_]?\s)'.format(word_pattern=number_word_pattern), line.strip(),
+        if re.match(r'^(\d+|{word_pattern})([.:\-_)]?\s)'.format(word_pattern=number_word_pattern), line.strip(),
                     flags=re.IGNORECASE):
             if current_item:
                 processed_items.append(current_item.strip())


### PR DESCRIPTION
Added ) to the list of canonical separators in text_utils.py parse_list function. This allows parsing of numbered lists like: 1) First item
2) Second item

Updated documentation in both text_utils.py and make_list_node.py to reflect the new separator.