### PR TITLE
Fix issue 2 in flickerfixes documentation

### DIFF
--- a/src/GUI/src/CustomNode.tsx
+++ b/src/GUI/src/CustomNode.tsx
@@ -91,7 +91,7 @@ const NodeHandle: React.FC<HandleProps> = ({
   );
 };
 
-export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> = ({
+const CustomNodeComponent: React.FC<{ data: CustomNodeData; selected?: boolean }> = ({
   data,
   selected
 }) => {
@@ -291,3 +291,5 @@ export const CustomNode: React.FC<{ data: CustomNodeData; selected?: boolean }> 
     </div>
   );
 };
+
+export const CustomNode = React.memo(CustomNodeComponent);


### PR DESCRIPTION
…erenders

The CustomNode component was causing full rerenders on every parent update because it wasn't memoized. This change wraps the component with React.memo to optimize rendering performance by only rerendering when props actually change.

Fixes flickerfixes.md issue 2