### PR TITLE
Fix issue 4 in flickerfixes documentation

### DIFF
--- a/src/GUI/src/GraphCanvas.tsx
+++ b/src/GUI/src/GraphCanvas.tsx
@@ -54,6 +54,12 @@ const GraphCanvasInner: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
   const selectedNodeIdsRef = useRef<Set<string>>(new Set());
   const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
   const viewportRef = useRef<{ x: number; y: number; zoom: number } | null>(null);
+  const workspaceNodesRef = useRef(workspaceNodes);
+
+  // Keep ref synchronized with workspaceNodes
+  useEffect(() => {
+    workspaceNodesRef.current = workspaceNodes;
+  }, [workspaceNodes]);
 
   const defaultEdgeConfig = useMemo(() => ({
     type: 'smoothstep' as const,
@@ -89,24 +95,24 @@ const GraphCanvasInner: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
 
   const handleBypassToggle = useCallback(async (sessionId: string) => {
     const targetNodeId = getOriginalNodeId(sessionId);
-    const node = workspaceNodes.find(n => n.session_id === targetNodeId);
+    const node = workspaceNodesRef.current.find(n => n.session_id === targetNodeId);
     if (!node) return;
 
     const currentBypass = node.parameters?.bypass?.value === true;
     await updateNode(targetNodeId, {
       parameters: { ...extractParameterValues(node), bypass: !currentBypass }
     });
-  }, [workspaceNodes, updateNode, extractParameterValues]);
+  }, [updateNode, extractParameterValues]);
 
   const handleDisplayToggle = useCallback(async (sessionId: string) => {
     const targetNodeId = getOriginalNodeId(sessionId);
-    const node = workspaceNodes.find(n => n.session_id === targetNodeId);
+    const node = workspaceNodesRef.current.find(n => n.session_id === targetNodeId);
     if (!node) return;
 
     const currentDisplay = node.parameters?.display?.value === true;
 
     if (!currentDisplay) {
-      const otherNodesWithDisplay = workspaceNodes.filter(
+      const otherNodesWithDisplay = workspaceNodesRef.current.filter(
         n => n.session_id !== targetNodeId && n.parameters?.display?.value === true
       );
 
@@ -122,7 +128,7 @@ const GraphCanvasInner: React.FC<GraphCanvasProps> = ({ onNodeFocus }) => {
     await updateNode(targetNodeId, {
       parameters: { ...extractParameterValues(node), display: !currentDisplay }
     });
-  }, [workspaceNodes, updateNode, extractParameterValues]);
+  }, [updateNode, extractParameterValues]);
 
   const onNodesChange = useCallback((changes: NodeChange<Node>[]) => {
     const filteredChanges = changes.filter(change => !shouldPreventDeselection(change));


### PR DESCRIPTION
…ary re-renders

The node transformation effect was running on every workspace change because handleBypassToggle and handleDisplayToggle callbacks depended on workspaceNodes, causing them to be recreated on every change. Since these callbacks were in the effect's dependency array, this triggered unnecessary re-renders.

Changes:
- Added workspaceNodesRef to maintain a stable reference to workspaceNodes
- Updated handleBypassToggle and handleDisplayToggle to use the ref instead of the prop
- Removed workspaceNodes from the callbacks' dependency arrays
- Added a sync effect to keep the ref updated

This ensures the callbacks have stable references and the transformation effect only runs when workspaceNodes or connections actually change in content, not when the callbacks are recreated.