### PR TITLE
Fix failing API tests

### DIFF
--- a/src/tests/test_api_endpoints.py
+++ b/src/tests/test_api_endpoints.py
@@ -81,7 +81,7 @@ def setup_test_workspace():
     }
 
 
-def test_endpoint(name: str, url: str, expected_status: int = 200) -> Dict[str, Any]:
+def check_endpoint(name: str, url: str, expected_status: int = 200) -> Dict[str, Any]:
     """Test a single endpoint and return results."""
     print(f"\n{name}")
     print("-" * 60)
@@ -138,25 +138,25 @@ def main():
     results = []
     
     # Test root endpoint
-    result = test_endpoint(
+    result = check_endpoint(
         "1. Root Health Check",
         BASE_URL
     )
     results.append(result)
     if result['success']:
         print(f"Response: {json.dumps(result['data'], indent=2)}")
-    
+
     # Test API info
-    result = test_endpoint(
+    result = check_endpoint(
         "2. API Info",
         API_BASE
     )
     results.append(result)
     if result['success']:
         print(f"Endpoints: {list(result['data']['endpoints'].keys())}")
-    
+
     # Test workspace endpoint
-    result = test_endpoint(
+    result = check_endpoint(
         "3. Get Workspace",
         f"{API_BASE}/workspace"
     )
@@ -166,27 +166,27 @@ def main():
         print(f"Nodes: {len(data['nodes'])}")
         print(f"Connections: {len(data['connections'])}")
         print(f"Globals: {len(data['globals'])}")
-        
+
         # Show node details
         if data['nodes']:
             print("\nNodes found:")
             for node in data['nodes']:
                 print(f"  - {node['name']} ({node['type']}) at {node['path']}")
-        
+
         # Show connections
         if data['connections']:
             print("\nConnections found:")
             for conn in data['connections']:
                 print(f"  - {conn['source_node_path']} -> {conn['target_node_path']}")
-        
+
         # Show globals
         if data['globals']:
             print("\nGlobals found:")
             for key, value in data['globals'].items():
                 print(f"  - {key} = {value}")
-    
+
     # Test list nodes endpoint
-    result = test_endpoint(
+    result = check_endpoint(
         "4. List All Nodes",
         f"{API_BASE}/nodes"
     )
@@ -202,11 +202,11 @@ def main():
             print(f"  Type: {first_node['type']}")
             print(f"  Path: {first_node['path']}")
             print(f"  Parameters: {len(first_node['parameters'])}")
-    
+
     # Test get specific node
     if result['success'] and nodes_list:
         session_id = nodes_list[0]['session_id']
-        result = test_endpoint(
+        result = check_endpoint(
             f"5. Get Node by Session ID ({session_id})",
             f"{API_BASE}/nodes/{session_id}"
         )
@@ -217,9 +217,9 @@ def main():
             print(f"Parameters:")
             for pname, pinfo in node['parameters'].items():
                 print(f"  - {pname}: {pinfo['value']} ({pinfo['type']})")
-    
+
     # Test 404 error
-    result = test_endpoint(
+    result = check_endpoint(
         "6. Test 404 Error (Invalid Session ID)",
         f"{API_BASE}/nodes/999999999",
         expected_status=404

--- a/src/tests/test_api_write_endpoints.py
+++ b/src/tests/test_api_write_endpoints.py
@@ -47,7 +47,7 @@ def clear_workspace():
     print("✓ Workspace cleared")
 
 
-def test_request(name: str, method: str, url: str, data: Dict = None, expected_status: int = 200) -> Dict[str, Any]:
+def make_request(name: str, method: str, url: str, data: Dict = None, expected_status: int = 200) -> Dict[str, Any]:
     """Test a single endpoint and return results."""
     print(f"\n{name}")
     print("-" * 60)
@@ -123,7 +123,7 @@ def main():
     # ========================================
     # TEST 1: Create TextNode
     # ========================================
-    result = test_request(
+    result = make_request(
         "1. Create TextNode",
         "POST",
         f"{API_BASE}/nodes",
@@ -142,7 +142,7 @@ def main():
     # ========================================
     # TEST 2: Create FileOutNode
     # ========================================
-    result = test_request(
+    result = make_request(
         "2. Create FileOutNode",
         "POST",
         f"{API_BASE}/nodes",
@@ -162,7 +162,7 @@ def main():
     # TEST 3: Update TextNode parameters
     # ========================================
     if 'text' in test_nodes:
-        result = test_request(
+        result = make_request(
             "3. Update TextNode Parameters",
             "PUT",
             f"{API_BASE}/nodes/{test_nodes['text']['session_id']}",
@@ -182,7 +182,7 @@ def main():
     # TEST 4: Update FileOutNode filename
     # ========================================
     if 'fileout' in test_nodes:
-        result = test_request(
+        result = make_request(
             "4. Update FileOutNode Filename",
             "PUT",
             f"{API_BASE}/nodes/{test_nodes['fileout']['session_id']}",
@@ -200,7 +200,7 @@ def main():
     # TEST 5: Create connection
     # ========================================
     if 'text' in test_nodes and 'fileout' in test_nodes:
-        result = test_request(
+        result = make_request(
             "5. Create Connection (Text → FileOut)",
             "POST",
             f"{API_BASE}/connections",
@@ -220,7 +220,7 @@ def main():
     # TEST 6: Execute FileOutNode
     # ========================================
     if 'fileout' in test_nodes:
-        result = test_request(
+        result = make_request(
             "6. Execute FileOutNode",
             "POST",
             f"{API_BASE}/nodes/{test_nodes['fileout']['session_id']}/execute",
@@ -244,7 +244,7 @@ def main():
     # ========================================
     # TEST 7: Set global variable
     # ========================================
-    result = test_request(
+    result = make_request(
         "7. Set Global Variable",
         "PUT",
         f"{API_BASE}/globals/TESTVAR",
@@ -257,7 +257,7 @@ def main():
     # ========================================
     # TEST 8: Get global variable
     # ========================================
-    result = test_request(
+    result = make_request(
         "8. Get Global Variable",
         "GET",
         f"{API_BASE}/globals/TESTVAR",
@@ -270,7 +270,7 @@ def main():
     # ========================================
     # TEST 9: List all globals
     # ========================================
-    result = test_request(
+    result = make_request(
         "9. List All Globals",
         "GET",
         f"{API_BASE}/globals",
@@ -286,7 +286,7 @@ def main():
     # TEST 10: Update node UI state
     # ========================================
     if 'text' in test_nodes:
-        result = test_request(
+        result = make_request(
             "10. Update Node UI State",
             "PUT",
             f"{API_BASE}/nodes/{test_nodes['text']['session_id']}",
@@ -304,7 +304,7 @@ def main():
     # TEST 11: Delete connection
     # ========================================
     if 'text' in test_nodes and 'fileout' in test_nodes:
-        result = test_request(
+        result = make_request(
             "11. Delete Connection",
             "DELETE",
             f"{API_BASE}/connections",
@@ -322,7 +322,7 @@ def main():
     # ========================================
     # TEST 12: Delete global variable
     # ========================================
-    result = test_request(
+    result = make_request(
         "12. Delete Global Variable",
         "DELETE",
         f"{API_BASE}/globals/TESTVAR",
@@ -336,7 +336,7 @@ def main():
     # TEST 13: Delete nodes
     # ========================================
     if 'text' in test_nodes:
-        result = test_request(
+        result = make_request(
             "13. Delete TextNode",
             "DELETE",
             f"{API_BASE}/nodes/{test_nodes['text']['session_id']}",
@@ -347,7 +347,7 @@ def main():
             print(f"✓ Deleted text node")
     
     if 'fileout' in test_nodes:
-        result = test_request(
+        result = make_request(
             "14. Delete FileOutNode",
             "DELETE",
             f"{API_BASE}/nodes/{test_nodes['fileout']['session_id']}",
@@ -360,7 +360,7 @@ def main():
     # ========================================
     # TEST 15: Verify workspace is empty
     # ========================================
-    result = test_request(
+    result = make_request(
         "15. Verify Empty Workspace",
         "GET",
         f"{API_BASE}/workspace",

--- a/src/tests/test_failing_endpoints.py
+++ b/src/tests/test_failing_endpoints.py
@@ -53,15 +53,15 @@ def clear_workspace():
     logger.info("Workspace cleared")
 
 
-def test_create_node(node_type: str, node_name: str, position: list) -> Dict[str, Any]:
+def check_create_node(node_type: str, node_name: str, position: list) -> Dict[str, Any]:
     """
     Test creating a single node.
-    
+
     Args:
         node_type: Type of node to create (e.g., "text", "file_out")
         node_name: Name for the node
         position: [x, y] position
-        
+
     Returns:
         Dictionary with test results
     """
@@ -222,20 +222,20 @@ def main():
     # ========================================
     # TEST 1: Create TextNode
     # ========================================
-    result1 = test_create_node(
+    result1 = check_create_node(
         node_type="text",
         node_name="test_text",
         position=[100.0, 100.0]
     )
     results.append(result1)
-    
+
     # Small delay between tests
     time.sleep(0.5)
-    
+
     # ========================================
     # TEST 2: Create FileOutNode
     # ========================================
-    result2 = test_create_node(
+    result2 = check_create_node(
         node_type="file_out",
         node_name="test_fileout",
         position=[300.0, 100.0]


### PR DESCRIPTION
Renamed helper functions to prevent pytest from treating them as test cases:
- test_endpoint() → check_endpoint() in test_api_endpoints.py
- test_request() → make_request() in test_api_write_endpoints.py
- test_create_node() → check_create_node() in test_failing_endpoints.py

These are standalone integration test scripts meant to be run directly, not pytest test cases. Pytest was trying to discover and run them, causing "fixture not found" errors.