### PR TITLE
Fix npm install script path configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,8 +112,6 @@ setup_gui() {
     if [ "$NODE_AVAILABLE" = true ]; then
         step "Installing GUI dependencies..."
 
-        npm install --quiet || warn "Root npm install failed"
-
         cd src/GUI || fail "Cannot cd to src/GUI"
         npm install --quiet || fail "GUI npm install failed"
 


### PR DESCRIPTION
- Remove root directory npm install that was failing
- Package.json is located in src/GUI, not at root
- Script now only runs npm install from correct src/GUI directory